### PR TITLE
Specify caching paths

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -24,15 +24,57 @@ resource "aws_cloudfront_distribution" "handbook_distribution" {
       }
     }
 
-    viewer_protocol_policy = "allow-all"
     min_ttl                = 0
     default_ttl            = 0
     max_ttl                = 0
+    viewer_protocol_policy = "redirect-to-https"
   }
 
   # Cache behavior with precedence 0
   ordered_cache_behavior {
-    path_pattern     = "/*"
+    path_pattern     = "*.png"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "*.svg"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "*.jpg"
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.s3_origin_id

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -46,8 +46,8 @@ resource "aws_cloudfront_distribution" "handbook_distribution" {
     }
 
     min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
@@ -67,8 +67,8 @@ resource "aws_cloudfront_distribution" "handbook_distribution" {
     }
 
     min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
@@ -88,8 +88,8 @@ resource "aws_cloudfront_distribution" "handbook_distribution" {
     }
 
     min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }


### PR DESCRIPTION
- Redirect `HTTP` -> `HTTPS` by default
- Do not cache by default
- Only apply cache behaviour to images
- Cache images