### PR TITLE
Use domain

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "burendo_handbook" {
-  bucket = local.environment_domain
+  bucket = local.environment_domain[local.environment]
 
   tags = merge(local.tags, {
     Name = "burendo-handbook"

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "burendo_handbook" {
-  bucket = "${local.environment_short_domain[local.environment]}.handbook.burendo.com"
+  bucket = local.environment_domain
 
   tags = merge(local.tags, {
     Name = "burendo-handbook"


### PR DESCRIPTION
old pattern placed a `.` at the start of the bucket name in production and fails.