### PR TITLE
remove leftover deps

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,7 +17,6 @@ jobs:
   build-handbook:
     name: "Build Handbook content"
     runs-on: ubuntu-latest
-    needs: deploy-infra
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Remove leftover dependancy from previous pipeline.  Causes action to fail to run as dependancy doesn't exist 🙄 