### PR TITLE
Make the github links different to each other to show where they actually go

### DIFF
--- a/burendo-handbook/docusaurus.config.js
+++ b/burendo-handbook/docusaurus.config.js
@@ -86,7 +86,7 @@ const config = {
         items: [
           {
             href: "https://github.com/BurendoUK/burendo-handbook-infrastructure",
-            label: "GitHub",
+            label: "GitHub Repo",
             position: "right",
           },
           {
@@ -125,7 +125,7 @@ const config = {
             title: "More",
             items: [
               {
-                label: "GitHub",
+                label: "GitHub Org",
                 href: "https://github.com/BurendoUK",
               },
             ],


### PR DESCRIPTION
Make the github links different to each other to show where they actually go