### PR TITLE
Report success or warning runs as well as failures

### DIFF
--- a/.github/workflows/merge-private.yml
+++ b/.github/workflows/merge-private.yml
@@ -119,7 +119,7 @@ jobs:
           set -e
           aws ssm terminate-session --session-id ${{ github.run_id }}-${{ github.run_number }}
 
-  report-failures:
+  report-runs:
     name: Report Status
     runs-on: ubuntu-latest
     needs: build-handbook
@@ -129,7 +129,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
-          notify_when: 'failure'
+          notify_when: 'success,failure,warnings'
           notification_title: '${{ github.workflow }} has ${{ job.status }}'
           message_format: '@here *${{ github.workflow }}* ${{ job.status }} in ${{ github.repository }} triggered by ${{ github.triggering_actor }}'
           footer: 'Run id is ${{ github.run_id }}'

--- a/.github/workflows/merge-public.yml
+++ b/.github/workflows/merge-public.yml
@@ -100,7 +100,7 @@ jobs:
           set -e
           aws ssm terminate-session --session-id ${{ github.run_id }}-${{ github.run_number }}
 
-  report-failures:
+  report-runs:
     name: Report Status
     runs-on: ubuntu-latest
     needs: build-handbook
@@ -110,7 +110,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
-          notify_when: 'failure'
+          notify_when: 'success,failure,warnings'
           notification_title: '${{ github.workflow }} has ${{ job.status }}'
           message_format: '@here *${{ github.workflow }}* ${{ job.status }} in ${{ github.repository }} triggered by ${{ github.triggering_actor }}'
           footer: 'Run id is ${{ github.run_id }}'

--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -300,7 +300,7 @@ jobs:
           set -e
           aws ssm terminate-session --session-id ${{ github.run_id }}-${{ github.run_number }}
 
-  report-failures:
+  report-runs:
     name: Report Status
     runs-on: ubuntu-latest
     needs: [build-private-handbook, build-public-handbook]
@@ -310,7 +310,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
-          notify_when: 'failure'
+          notify_when: 'success,failure,warnings'
           notification_title: '${{ github.workflow }} has ${{ job.status }}'
           message_format: '@here *${{ github.workflow }}* ${{ job.status }} in ${{ github.repository }} triggered by ${{ github.triggering_actor }}'
           footer: 'Run id is ${{ github.run_id }}'


### PR DESCRIPTION
It's useful to know when updates to the handbook have actually been deployed so this will report success and warnings too. It's not a high churn so I doubt we'll start getting 100s of notifications and can refine then if we do.